### PR TITLE
Fix typo in English cover

### DIFF
--- a/template/cover_en.typ
+++ b/template/cover_en.typ
@@ -152,7 +152,7 @@
     info.major,
   )
   display_info(
-    "Thesis Aadvisor：",
+    "Thesis Advisor：",
     info.supervisor,
   )
   // render submit date


### PR DESCRIPTION
"Aadvisor" to "Advisor"