### PR TITLE
feat: English-text related features

### DIFF
--- a/sections/1_lorem.typ
+++ b/sections/1_lorem.typ
@@ -1,4 +1,5 @@
 #import "../template/template.typ": *
+
 = 一级标题
 
 == 二级标题

--- a/sections/1_lorem.typ
+++ b/sections/1_lorem.typ
@@ -1,0 +1,16 @@
+#import "../template/template.typ": *
+= 一级标题
+
+== 二级标题
+
+=== 三级标题
+
+#lorem(150)
+
+The following equation states the Pythagorean theorem:
+
+$
+a^2 = b^2 + c^2
+$ <pt>
+
+where $a, b, c$ denote lengths of sides of a triangle. This will later be referenced.

--- a/sections/2_introduction.typ
+++ b/sections/2_introduction.typ
@@ -1,0 +1,9 @@
+#import "../template/template.typ": *
+
+= Introduction (`sections/2_introduction.typ`)
+
+This is a introductory section included from the main file `thesis.typ` but written inside `sections/2_introduction.typ`. Note that you will need to manually handle function import via the following header:
+```typst
+#import "../template/template.typ": *
+```
+You might as well import only functions you would like to use.

--- a/sections/3_demonstration.typ
+++ b/sections/3_demonstration.typ
@@ -1,6 +1,24 @@
 #import "../template/template.typ": *
 = 示例 (`sections/3_demonstration.typ`)
 
+== 段落缩进与公式缩进
+
+此段落用以演示特性：在文章首段落缩进2字符。
+
+此段落用以演示特性：不再在公式结束时首行缩进。
+$
+  bold(c) = integral_(H^2) f (bold(p), bold(omega)_i, bold(omega)_o) L_i (bold(p), bold(omega)_i) abs(bold(N) dot bold(omega)_i) d bold(omega)_i
+$
+其中$H^2$代表积分的半球。
+
+此段落用以演示特性：标记公式的结束并换行。要强制换行，使用`#force_indent()`.
+$
+  bold(c) = integral_(H^2) f (bold(p), bold(omega)_i, bold(omega)_o) L_i (bold(p), bold(omega)_i) abs(bold(N) dot bold(omega)_i) d bold(omega)_i.
+$
+
+#force_indent()
+此段落标记一般不会出现的换行测试。
+
 == 引用示例 <引用示例>
 
 #lorem(20)@wang2010guide #lorem(20) @kopka2004guide 如 @图片示例 和 @表格示例 所示，Typst提供了方便的引用功能，我们也可以通过在标题后加`<some-tag-name>`引用特定的段落，就像 @引用示例 所述的那样。

--- a/sections/3_demonstration.typ
+++ b/sections/3_demonstration.typ
@@ -17,7 +17,13 @@ $
 $
 
 #force_indent()
-此段落标记一般不会出现的换行测试。
+此段落标记一般不会出现的*换行测试*。
+
+The following equation is an alternative form of the *radiative transfer equation*, or RTE, used to describe the behavior of scattering & attenuation of light along a light path:
+$
+  bold(L)(bold(o), bold(d)) = integral_(tau_n)^(tau_f) T (bold(o), bold(d)) (Sigma_i (1 - e^(- sigma_i rho_i (bold(o) + tau(bold(d)))))bold(c)_i (bold(d))) d tau
+$
+where $bold(c)_i (bold(d)) = phi_(bold(beta)_i) (bold(d))$ is the color of the $i$th transparent primitive.
 
 == 引用示例 <引用示例>
 

--- a/sections/3_demonstration.typ
+++ b/sections/3_demonstration.typ
@@ -1,4 +1,5 @@
 #import "../template/template.typ": *
+
 = 示例 (`sections/3_demonstration.typ`)
 
 == 段落缩进与公式缩进

--- a/sections/3_demonstration.typ
+++ b/sections/3_demonstration.typ
@@ -1,0 +1,40 @@
+#import "../template/template.typ": *
+= 示例 (`sections/3_demonstration.typ`)
+
+== 引用示例 <引用示例>
+
+#lorem(20)@wang2010guide #lorem(20) @kopka2004guide 如 @图片示例 和 @表格示例 所示，Typst提供了方便的引用功能，我们也可以通过在标题后加`<some-tag-name>`引用特定的段落，就像 @引用示例 所述的那样。
+
+== 脚注示例
+
+#lorem(20)#footnote("这是一个脚注示例")
+
+$
+a^2 = b^2 + c^2
+$ <pt2>
+
+This is a reference of equation @pt from another subsection, and the above equation @pt2.
+
+== 图片示例
+
+#figure(
+  caption: link("https://www.bilibili.com/opus/792419765560803378")[May. 06, 2023 立夏，画师：\@Setaria_italica ],
+  image(
+    width: 30%,
+    "../images/Lixia.jpg"
+  )
+) <图片示例>
+
+== 表格示例
+
+#figure(
+	table(
+		columns: 4,
+		[],[col-1],[col-2],[col3],
+		[row-1],[1,1],[1,2],[1,3],
+		[row-2],[2,1],[2,2],[2,3],
+		[row-3],[3,1],[3,2],[3,3],
+	),
+	caption: "表格示例"
+)<表格示例>
+#dataSource("表格数据来源：实验数据")

--- a/sections/appendix.typ
+++ b/sections/appendix.typ
@@ -1,3 +1,5 @@
+#import "../template/template.typ": *
+
 == 附录A 代码示例
 
 ```cpp

--- a/sections/appendix.typ
+++ b/sections/appendix.typ
@@ -1,0 +1,11 @@
+== 附录A 代码示例
+
+```cpp
+#include <iostream>
+using namespace std;
+
+int main() {
+	cout << "Hello, world!" << endl;
+	return 0;
+}
+```

--- a/template/acknowledgement.typ
+++ b/template/acknowledgement.typ
@@ -1,6 +1,6 @@
 #import "../utils/font.typ": *
 
-#let acknoledgement(
+#let acknowledgement(
   show_both: false,
   body
 ) = {

--- a/template/template.typ
+++ b/template/template.typ
@@ -1,15 +1,15 @@
-#import "abstract_header.typ" : *
-#import "abstract_zh.typ" : *
-#import "abstract_en.typ" : *
-#import "acknowledge.typ" : *
-#import "appendix.typ" : *
-#import "content.typ" : *
-#import "cover_zh.typ" : *
-#import "cover_en.typ" : *
-#import "decl_zh.typ" : *
+#import "abstract_header.typ": *
+#import "abstract_zh.typ": *
+#import "abstract_en.typ": *
+#import "acknowledge.typ": *
+#import "appendix.typ": *
+#import "content.typ": *
+#import "cover_zh.typ": *
+#import "cover_en.typ": *
+#import "decl_zh.typ": *
 #import "decl_en.typ": *
-#import "references.typ" : *
-#import "../utils/style.typ": documentClass
+#import "references.typ": *
+#import "../utils/style.typ": documentClass, force_indent
 
 #let cover(
   en: false,
@@ -17,20 +17,23 @@
   info: (:),
   fonts: (:),
 ) = {
-  info = ( 
-    clc: "CLC",
-    thesis_id: "Thesis ID",
-    confidentiality_level: "Confidential Level",
-    udc: "UDC",
-    title: "Title",
-    subtitle: "Subtitle",
-    author: "Author",
-    student_id: "Student ID",
-    department: "Department",
-    major: "Major",
-    supervisor: "Supervisor",
-    submit_date: datetime.today(),
-  )+info
+  info = (
+    (
+      clc: "CLC",
+      thesis_id: "Thesis ID",
+      confidentiality_level: "Confidential Level",
+      udc: "UDC",
+      title: "Title",
+      subtitle: "Subtitle",
+      author: "Author",
+      student_id: "Student ID",
+      department: "Department",
+      major: "Major",
+      supervisor: "Supervisor",
+      submit_date: datetime.today(),
+    )
+      + info
+  )
   if en {
     cover_en(
       anonymous: anonymous,
@@ -52,7 +55,7 @@
   anonymous: false,
   print_date: datetime.today(),
 ) = {
-  if(en){
+  if (en) {
     decl_en(anonymous: anonymous, print_date: print_date)
   } else {
     decl_zh(anonymous: anonymous, print_date: print_date)
@@ -61,22 +64,25 @@
 }
 
 #let make_default_abstract_info(
-  info: (:)
+  info: (:),
 ) = {
   let ret = (
-    clc: "CLC",
-    thesis_id: "Thesis ID",
-    confidentiality_level: "Confidential Level",
-    udc: "UDC",
-    title: "Title",
-    subtitle: "Subtitle",
-    author: "Author",
-    student_id: "Student ID",
-    department: "Department",
-    major: "Major",
-    supervisor: "Supervisor",
-    submit_date: datetime.today(),
-  ) + info
+    (
+      clc: "CLC",
+      thesis_id: "Thesis ID",
+      confidentiality_level: "Confidential Level",
+      udc: "UDC",
+      title: "Title",
+      subtitle: "Subtitle",
+      author: "Author",
+      student_id: "Student ID",
+      department: "Department",
+      major: "Major",
+      supervisor: "Supervisor",
+      submit_date: datetime.today(),
+    )
+      + info
+  )
   return ret
 }
 
@@ -91,18 +97,17 @@
   info_en: (:),
   fonts: (:),
   body_zh: "",
-  body_en: ""
+  body_en: "",
 ) = {
-
   info_zh = make_default_abstract_info(info: info_zh)
   info_en = make_default_abstract_info(info: info_en)
-  
+
   abstract_header(
     en: prefer_en_header, // By default thesis header should be Chinese no matter what
     anonymous: anonymous,
     fonts: fonts,
     info_zh: info_zh,
-    info_en: info_en
+    info_en: info_en,
   )
 
   if (en) {
@@ -120,13 +125,12 @@
       info: info_zh,
       fonts: fonts,
     )[#body_zh]
-  }
-  else {
+  } else {
     abstract_zh(
       keywords: keywords_zh,
       fonts: fonts,
     )[#body_zh]
-    
+
     pagebreak(weak: true)
 
     abstract_en(
@@ -143,13 +147,13 @@
   pagebreak()
 }
 
-	#let dataSource(
-		body
-	) = {
-		set align(center)
-		text(
-			font: FONTS.宋体,
-			size: FSIZE.五号,
-			body
-		)
-	}
+#let dataSource(
+  body,
+) = {
+  set align(center)
+  text(
+    font: FONTS.宋体,
+    size: FSIZE.五号,
+    body,
+  )
+}

--- a/template/template.typ
+++ b/template/template.typ
@@ -1,7 +1,7 @@
 #import "abstract_header.typ": *
 #import "abstract_zh.typ": *
 #import "abstract_en.typ": *
-#import "acknowledge.typ": *
+#import "acknowledgement.typ": *
 #import "appendix.typ": *
 #import "content.typ": *
 #import "cover_zh.typ": *

--- a/thesis.typ
+++ b/thesis.typ
@@ -102,79 +102,18 @@
 #set page(numbering: "1")
 #counter(page).update(1)
 
-= 一级标题
+#include "sections/1_lorem.typ"
 
-== 二级标题
+#include "sections/2_introduction.typ"
 
-=== 三级标题
-
-#lorem(300)
-
-$
-a^2 = b^2 + c^2
-$
-
-$
-a^2 = b^2 + c^2
-$ <pt>
-
-= 示例
-
-== 引用示例 <引用示例>
-
-#lorem(20)@wang2010guide #lorem(20) @kopka2004guide 如 @图片示例 和 @表格示例 所示，Typst提供了方便的引用功能，我们也可以通过在标题后加`<some-tag-name>`引用特定的段落，就像 @引用示例 所述的那样。
-
-== 脚注示例
-
-#lorem(20)#footnote("这是一个脚注示例")
-
-
-$
-a^2 = b^2 + c^2
-$ <pt2>
-
-This is a reference of equation @pt, and the above equation @pt2.
-
-== 图片示例
-
-#figure(
-  caption: link("https://www.bilibili.com/opus/792419765560803378")[May. 06, 2023 立夏，画师：\@Setaria_italica ],
-  image(
-    width: 30%,
-    "./images/Lixia.jpg"
-  )
-) <图片示例>
-
-== 表格示例
-
-#figure(
-	table(
-		columns: 4,
-		[],[col-1],[col-2],[col3],
-		[row-1],[1,1],[1,2],[1,3],
-		[row-2],[2,1],[2,2],[2,3],
-		[row-3],[3,1],[3,2],[3,3],
-	),
-	caption: "表格示例"
-)<表格示例>
-#dataSource("表格数据来源：实验数据")
+#include "sections/3_demonstration.typ"
 
 #references(show_both: true)
 
 #appendix(show_both: true)
 #set heading(numbering: none)
 
-== 附录A 代码示例
-
-```cpp
-#include <iostream>
-using namespace std;
-
-int main() {
-	cout << "Hello, world!" << endl;
-	return 0;
-}
-```
+#include "sections/appendix.typ"
 
 #acknoledgement(show_both: true)[
   截至 #datetime_display_zh(datetime.today())，本模板当前版本为v0.1.0。 感谢在模板开发过程中提出宝贵意见和建议的同学们，以及每一位使用本模板的同学，你们的支持是模板不断更新迭代的动力，也是笔者最大的荣幸。

--- a/thesis.typ
+++ b/thesis.typ
@@ -1,4 +1,3 @@
-
 #import "template/template.typ": *
 
 // Select the active text language: Chinese(zh) or English(en)
@@ -108,10 +107,11 @@
 
 #include "sections/3_demonstration.typ"
 
+#set heading(numbering: none)
+
 #references(show_both: true)
 
 #appendix(show_both: true)
-#set heading(numbering: none)
 
 #include "sections/appendix.typ"
 

--- a/thesis.typ
+++ b/thesis.typ
@@ -115,6 +115,6 @@
 
 #include "sections/appendix.typ"
 
-#acknoledgement(show_both: true)[
+#acknowledgement(show_both: true)[
   截至 #datetime_display_zh(datetime.today())，本模板当前版本为v0.1.0。 感谢在模板开发过程中提出宝贵意见和建议的同学们，以及每一位使用本模板的同学，你们的支持是模板不断更新迭代的动力，也是笔者最大的荣幸。
 ]

--- a/utils/style.typ
+++ b/utils/style.typ
@@ -35,7 +35,9 @@
 			all: false,
 		),
 		leading: 1.5*FSIZE.小四,
+		justify: true,
 	)
+	#set figure(gap: 1.2em)
 	// 图片样式
 	#show figure.caption: it => {
 		set text(
@@ -43,6 +45,7 @@
 			size: FSIZE.五号,
 			weight: "regular",
 		)
+		set par(leading: 1.5*FSIZE.五号)
 		it
 	}
 	// 表格样式

--- a/utils/style.typ
+++ b/utils/style.typ
@@ -5,6 +5,9 @@
 
 #import "headings.typ" : *
 
+// Generate a fake paragraph for indent at the next paragraph
+#let force_indent() = [#context {[#box();#v(-measure(block()+block()).height)]}]
+
 #let documentClass(lang: "zh", body) = [
 	// 标题样式
 	#import "@preview/cuti:0.3.0": show-fakebold
@@ -17,6 +20,8 @@
 			weight: "regular",
 		)
 		it
+		v(-0.5*FSIZE.小四)
+    par(leading: 1.0em)[#text(size:0.0em)[#h(0.0em)]] // Fake paragraph for first-line-indent of the actual first paragraph
 	}
 	// 正文样式
 	#set text(
@@ -27,7 +32,7 @@
 	#set par(
 		first-line-indent: (
 			amount: 2*FSIZE.小四,
-			all: true,
+			all: false,
 		),
 		leading: 1.5*FSIZE.小四,
 	)

--- a/utils/style.typ
+++ b/utils/style.typ
@@ -10,8 +10,8 @@
 
 #let documentClass(lang: "zh", body) = [
 	// 标题样式
-	#import "@preview/cuti:0.3.0": show-fakebold
-	#show: show-fakebold
+	#import "@preview/cuti:0.3.0": show-cn-fakebold
+	#show: show-cn-fakebold
 	#set heading(numbering: sustech-undergraduate-heading-numbering)
 	#show heading: it => {
 		set text(


### PR DESCRIPTION
- [x] space after heading & indentation after equations
- [x] fix spelling of function `acknowledgement` ... other typos
- [x] demonstration of splitting the document into multiple files (for organizational purposes)
- [x] use `show-cn-fakebold` instead of fakebolding everything.